### PR TITLE
IA-16 :: introduce forwardAuth middleware to enforce authz

### DIFF
--- a/charts/auth-service/templates/forward-auth.yaml
+++ b/charts/auth-service/templates/forward-auth.yaml
@@ -1,0 +1,14 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: "{{ include ".helm.fullname" . }}-forward-auth"
+  namespace: {{ .Values.namespace }}
+spec:
+  forwardAuth:
+    address: http://baseline-oathkeeper-api:4456/decisions
+    authRequestHeaders:
+    - accept
+    - accept-encoding
+    - authorization
+    authResponseHeaders:
+    - x-identity

--- a/charts/auth-service/templates/ingressroute.yaml
+++ b/charts/auth-service/templates/ingressroute.yaml
@@ -8,8 +8,8 @@ spec:
   entryPoints:
     - web
   routes:
-    - match: (PathPrefix("/{{ .Values.image.domainPath }}"))
-      kind: Rule
+    - kind: Rule
+      match: (Path("/{{ .Values.image.domainPath }}/(login|realms)"))
       services:
         - name: {{ include ".helm.fullname" . }}
           kind: Service
@@ -18,4 +18,15 @@ spec:
       middlewares:
       - name: "{{ include ".helm.fullname" . }}-strip"
       {{ end }}
+    - kind: Rule
+      match: (PathPrefix("/{{ .Values.image.domainPath }}"))
+      services:
+        - name: {{ include ".helm.fullname" . }}
+          kind: Service
+          port: {{ .Values.image.containerPort }}
+      middlewares:
+      {{ if (not (hasKey .Values.image "noStripPath")) }}
+      - name: "{{ include ".helm.fullname" . }}-strip"
+      {{ end }}
+      - name: "{{ include ".helm.fullname" . }}-forward-auth"
 {{ end }}

--- a/charts/auth-service/templates/middleware.yaml
+++ b/charts/auth-service/templates/middleware.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "{{ include ".helm.fullname" . }}-strip"
   namespace: {{ .Values.namespace }}
 spec:
-  stripPrefix:
-    prefixes:
+  stripPrefixRegex:
+    regex:
       - "/{{ .Values.image.domainPath }}"
 {{ end }}


### PR DESCRIPTION
Introduced forwardAuth middleware to enforce authz for protected APIs through Oathkeeper. Moreover, we're enhancing the routing rules to distinguish protected APIs from the unprotected ones (`/login` and `/realms/detect`).

## [ Name of Component Added / Modified]
Traefik's forwardAuth middleware, Auth Service's IngressRoute

### Types of Changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New component
- [X] Enhancement/optimization
- [ ] Documentation
- [ ] Test

### Issues Addressed
* [IA-16](https://htw-cloud.atlassian.net/browse/IA-16)