### PR TITLE
(IA-77) Add paths for Swagger ui and json to be available in auth-services

### DIFF
--- a/charts/auth-service/templates/ingressroute.yaml
+++ b/charts/auth-service/templates/ingressroute.yaml
@@ -9,7 +9,7 @@ spec:
     - web
   routes:
     - kind: Rule
-      match: (Path("/{{ .Values.image.domainPath }}/{path:(login||realms/detect||logout||api(-json))}"))
+      match: (Path("/{{ .Values.image.domainPath }}/{path:(login||realms/detect||logout||api(-json)?)}"))
       services:
         - name: {{ include ".helm.fullname" . }}
           kind: Service


### PR DESCRIPTION
## Description
Adds the /api and /api-json paths to be available in the ingress routes rules for auth-services

### Types of Changes / 변경 유형
<!--- What types of changes does your code introduce? / 귀하의 코드는 어떤 유형의 변경을 도입합니까? -->
- [ ] Core / 핵심
- [ ] Bugfix / 버그 수정
- [ ] New component / 새 구성 요소
- [ ] Enhancement/optimization / 개선/최적화
- [ ] Documentation / 문서
- [ ] Test / 테스트

### Issues Addressed / 해결된 문제
* [KEY-123](https://htw-cloud.atlassian.net/browse/KEY-123)

### Checklist / 체크리스트
<!--- Used to represent the acceptance criteria of the Jira ticket / 
Jira 티켓의 허용 기준을 나타내는 데 사용됩니다. -->
- [ ] Meets Design Standards / 설계 표준 충족
- [ ] Passes Tests / 테스트 통과
- [ ] Meets [Definition of Done](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done) / [완료의 정의](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done) 충족
