### PR TITLE
fix: updated to use Kubernetes secret and added initContainers 

### DIFF
--- a/charts/core-edge/templates/cert.yaml
+++ b/charts/core-edge/templates/cert.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: "{{ include ".helm.fullname" . }}-certs"
+type: Opaque
 data:
-{{ (.Files.Glob "certs/*").AsConfig | indent 2 }}
+{{ (.Files.Glob "certs/*").AsSecrets | indent 2 }}
 

--- a/charts/core-edge/templates/edgeccs-deployment.yaml
+++ b/charts/core-edge/templates/edgeccs-deployment.yaml
@@ -18,24 +18,59 @@ spec:
         {{- include ".helm.selectorLabels" . | nindent 8 }}
         app: edgeccs
     spec:
+      initContainers:
+      - name: init-copy-device-certs-files-from-secret
+        image: busybox:latest
+        volumeMounts:
+          - name: shared-volume
+            mountPath: /cert
+          - name: device-certs
+            readOnly: true
+            mountPath: /cert/device_cert_as_secret
+        command: ['sh', '-c', "mkdir -p /cert/device_cert; cp -Lr /cert/device_cert_as_secret/* /cert/device_cert"]
       containers:
+{{- if .Values.keymanager }}
+        - name: keymanager
+          {{- if .Values.keymanager.image.tag }}
+          image: {{ .Values.keymanager.image.repository }}@{{ .Values.keymanager.image.tag }}
+          {{- else }}
+          image: {{ .Values.keymanager.image.repository }}:latest
+          {{- end }}
+          imagePullPolicy: Always
+          {{- if .Values.keymanager.image.env }}
+          env:
+            {{- toYaml .Values.keymanager.image.env | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /cert
+            - name: device-certs
+              readOnly: true
+              mountPath: /cert/device_cert_as_secret
+{{- end }}
         - name: edgeccs
-          {{- if .Values.edgeccs.image.digest }}
-          image: {{ .Values.edgeccs.image.repository }}@{{ .Values.edgeccs.image.digest }}
+          {{- if .Values.edgeccs.image.tag }}
+          image: {{ .Values.edgeccs.image.repository }}@{{ .Values.edgeccs.image.tag }}
           {{- else }}
           image: {{ .Values.edgeccs.image.repository }}:latest
           {{- end }}
           imagePullPolicy: Always
+          {{- if .Values.edgeccs.image.env }}
+          env:
+            {{- toYaml .Values.edgeccs.image.env | nindent 12 }}
+          {{- end }}
           envFrom:
             - secretRef:
                 name: "baseline-redis-secret"
           volumeMounts:
-          - name: cert
+          - name: shared-volume
             mountPath: /cert
       volumes:
-        - name: cert
-          configMap:
-            name: "{{ include ".helm.fullname" . }}-certs"
+        - name: shared-volume
+          emptyDir: {}
+        - name: device-certs
+          secret:
+            secretName: "{{ include ".helm.fullname" . }}-certs"
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets }}

--- a/charts/core-edge/values.yaml
+++ b/charts/core-edge/values.yaml
@@ -1,22 +1,54 @@
 
 imagePullSecrets: dockerconfigjson-github-com
+namespace: hanwha
+
+service:
+  type: ClusterIP
 
 scs:
   replicaCount: 1
+  tag: latest
   image:
     repository: ghcr.io/htaic/scsrun
-
-edgeccs:
-  replicaCount: 1
-  image:
-    repository: ghcr.io/htaic/edgeccs
+  resources:
+    requests:
+      cpu: 250m
+      memory: 350Mi
 
 keymanager:
   replicaCount: 1
+  tag: latest
   image:
     repository: ghcr.io/htaic/edgekeymanagerrun
+    env:
+      - name: edgeId
+        value: YOUR_EDGE_ID
+  resources:
+    requests:
+      cpu: 250m
+      memory: 350Mi
+
+edgeccs:
+  replicaCount: 1
+  tag: latest
+  image:
+    repository: ghcr.io/htaic/edgeccs
+    env:
+      - name: edgeId
+        value: YOUR_EDGE_ID
+      - name: awsIotDataEndpoint
+        value: YOUR_AWS_IOT_DATA_ENDPOINT
+  resources:
+    requests:
+      cpu: 250m
+      memory: 350Mi
 
 dcs:
   replicaCount: 1
+  tag: latest
   image:
     repository: ghcr.io/htaic/edgedcsmanagerrun
+  resources:
+    requests:
+      cpu: 250m
+      memory: 350Mi


### PR DESCRIPTION
to dereference linked device_cert files to regular files due to curl_formadd issue

## [ helm-carts ]

Due to curl_formadd issue on both Kubernetes configmap and secret, added initContainers to create /cert/device_cert folder

### 변경 유형 / Types of Changes / Tipos de Cambios
<!--- 귀하의 코드는 어떤 유형의 변경을 도입합니까? / What types of changes does your code introduce? / ¿Qué tipos de cambios introduce su código? -->
- [ ] 핵심 / Core / Centro
- [ X ] 버그 수정 / Bugfix / Corrección de Error
- [ ] 새 구성 요소 / New component / Nuevo componente
- [ ] 개선/최적화 / Enhancement/optimization / Mejora/optimización
- [ ] 문서 / Documentation / Documentación
- [ ] 테스트 / Test / Prueba

### 해결된 문제 / Issues Addressed / Problemas Abordados
* [vid-240](https://htw-cloud.atlassian.net/browse/VID-240)

### 체크리스트 / Checklist / Lista de Verificación
<!--- Jira 티켓의 허용 기준을 나타내는 데 사용됩니다. /
      Used to represent the acceptance criteria of the Jira ticket / 
      Se utiliza para representar los criterios de aceptación del ticket de Jira -->
- [ ] 설계 표준 충족 / Meets Design Standards / Cumple con los Estándares de Diseño
- [ ] 테스트 통과 / Passes Tests / Pasa las Pruebas
- [ ] 만나다 [완료의 정의](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done) / Meets [Definition of Done](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done) / Satisface [Definición de Hecho](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done)
