### PR TITLE
IA-557: (Kafka-rest-node services) Fixing Consumer Group Name Value 

### DIFF
--- a/charts/kafka-rest-consumer-service/values.yaml
+++ b/charts/kafka-rest-consumer-service/values.yaml
@@ -12,6 +12,9 @@ image:
       value: '12'
     - name: KAFKA_REST_URL
       value: KAFKA_REST_PROXY_URL # this value is different between cloud and edge (edge has to go throuh internet to reach Traefik. In cloud, requests are made to Traefik's internal endpoint)
+    # Default Value is set at the image level https://github.com/htaic/kafka-rest-node-services/blob/main/Dockerfile-consumer
+    # - name: GROUP_NAME
+    #   value: A_CONSUMER_GROUP_NAME # this must be unique per deployment instance. For example, cloud instance has a different value than any edge location.
     - name: LOG_LEVEL
       value: DEBUG
     - name: LOG_SINK

--- a/charts/kafka-rest-consumer-service/values.yaml
+++ b/charts/kafka-rest-consumer-service/values.yaml
@@ -12,8 +12,6 @@ image:
       value: '12'
     - name: KAFKA_REST_URL
       value: KAFKA_REST_PROXY_URL # this value is different between cloud and edge (edge has to go throuh internet to reach Traefik. In cloud, requests are made to Traefik's internal endpoint)
-    - name: GROUP_NAME
-      value: A_CONSUMER_GROUP_NAME # this must be unique per deployment instance. For example, cloud instance has a different value than any edge location.
     - name: LOG_LEVEL
       value: DEBUG
     - name: LOG_SINK


### PR DESCRIPTION
The default value is already being set at the app level here: https://github.com/htaic/kafka-rest-node-services/blob/cc99d04ba64296e4b42e5463a7f3b850c987238a/Dockerfile-consumer#L8

## [ 추가/수정된 구성 요소의 이름 ] / [ Fixing Kafka Consumer Group Error ] / [ Nombre del Componente Agregado/Modificado ]
<!--- 여기에서 변경 사항을 자세히 설명하세요 / Describe your changes in detail here / Describa sus cambios en detalle aquí  -->

### 변경 유형 / Types of Changes / Tipos de Cambios
<!--- 귀하의 코드는 어떤 유형의 변경을 도입합니까? / What types of changes does your code introduce? / ¿Qué tipos de cambios introduce su código? -->
- [ ] 핵심 / Core / Centro
- [x] 버그 수정 / Bugfix / Corrección de Error
- [ ] 새 구성 요소 / New component / Nuevo componente
- [ ] 개선/최적화 / Enhancement/optimization / Mejora/optimización
- [ ] 문서 / Documentation / Documentación
- [ ] 테스트 / Test / Prueba

### 해결된 문제 / Issues Addressed / Problemas Abordados
* [IA-557](https://htw-cloud.atlassian.net/browse/IA-557) 

### 체크리스트 / Checklist / Lista de Verificación
<!--- Jira 티켓의 허용 기준을 나타내는 데 사용됩니다. /
      Used to represent the acceptance criteria of the Jira ticket / 
      Se utiliza para representar los criterios de aceptación del ticket de Jira -->
- [ ] 설계 표준 충족 / Meets Design Standards / Cumple con los Estándares de Diseño
- [ ] 테스트 통과 / Passes Tests / Pasa las Pruebas
- [ ] 만나다 [완료의 정의](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done) / Meets [Definition of Done](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done) / Satisface [Definición de Hecho](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done)


[IA-557]: https://htw-cloud.atlassian.net/browse/IA-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ