### PR TITLE
chore: VID-253

### DIFF
--- a/charts/edge-webrtc-service/templates/deployment.yaml
+++ b/charts/edge-webrtc-service/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: "baseline-redis-secret"
           {{- if .Values.image.env }}
           env: 
             {{- toYaml .Values.image.env | nindent 12 }}

--- a/charts/edge-webrtc-service/templates/deployment.yaml
+++ b/charts/edge-webrtc-service/templates/deployment.yaml
@@ -31,11 +31,6 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        {{- if .Values.sidecarimage }}
-        - name: "{{ .Values.sidecarimage.name }}"
-          image: "{{ .Values.sidecarimage.repository }}:{{ .Values.sidecarimage.tag }}"
-          imagePullPolicy: {{ .Values.sidecarimage.pullPolicy }}
-        {{- end }}      
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -63,6 +58,11 @@ spec:
           #     port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.sidecarimage }}
+        - name: "{{ .Values.sidecarimage.name }}"
+          image: "{{ .Values.sidecarimage.repository }}:{{ .Values.sidecarimage.tag }}"
+          imagePullPolicy: {{ .Values.sidecarimage.pullPolicy }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/rtsp-service/templates/deployment.yaml
+++ b/charts/rtsp-service/templates/deployment.yaml
@@ -33,11 +33,6 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        {{- if .Values.sidecarimage }}
-        - name: "{{ .Values.sidecarimage.name }}"
-          image: "{{ .Values.sidecarimage.repository }}:{{ .Values.sidecarimage.tag }}"
-          imagePullPolicy: {{ .Values.sidecarimage.pullPolicy }}
-        {{- end }}      
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -78,6 +73,11 @@ spec:
             periodSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.sidecarimage }}
+        - name: "{{ .Values.sidecarimage.name }}"
+          image: "{{ .Values.sidecarimage.repository }}:{{ .Values.sidecarimage.tag }}"
+          imagePullPolicy: {{ .Values.sidecarimage.pullPolicy }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/signaling-service/templates/deployment.yaml
+++ b/charts/signaling-service/templates/deployment.yaml
@@ -31,11 +31,6 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        {{- if .Values.sidecarimage }}
-        - name: "{{ .Values.sidecarimage.name }}"
-          image: "{{ .Values.sidecarimage.repository }}:{{ .Values.sidecarimage.tag }}"
-          imagePullPolicy: {{ .Values.sidecarimage.pullPolicy }}
-        {{- end }}      
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -73,6 +68,11 @@ spec:
             periodSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.sidecarimage }}
+        - name: "{{ .Values.sidecarimage.name }}"
+          image: "{{ .Values.sidecarimage.repository }}:{{ .Values.sidecarimage.tag }}"
+          imagePullPolicy: {{ .Values.sidecarimage.pullPolicy }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/video-connection-manager/templates/deployment.yaml
+++ b/charts/video-connection-manager/templates/deployment.yaml
@@ -28,11 +28,6 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        {{- if .Values.sidecarimage }}
-        - name: "{{ .Values.sidecarimage.name }}"
-          image: "{{ .Values.sidecarimage.repository }}:{{ .Values.sidecarimage.tag }}"
-          imagePullPolicy: {{ .Values.sidecarimage.pullPolicy }}
-        {{- end }}      
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -52,6 +47,11 @@ spec:
           args: [ {{.Values.image.args}} ]
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.sidecarimage }}
+        - name: "{{ .Values.sidecarimage.name }}"
+          image: "{{ .Values.sidecarimage.repository }}:{{ .Values.sidecarimage.tag }}"
+          imagePullPolicy: {{ .Values.sidecarimage.pullPolicy }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## [ edge-webrtc-service ]

- added redis secrets as environments
- switching the sidecar container as the second container

### 변경 유형 / Types of Changes / Tipos de Cambios
<!--- 귀하의 코드는 어떤 유형의 변경을 도입합니까? / What types of changes does your code introduce? / ¿Qué tipos de cambios introduce su código? -->
- [ X ] 핵심 / Core / Centro
- [ ] 버그 수정 / Bugfix / Corrección de Error
- [ ] 새 구성 요소 / New component / Nuevo componente
- [ ] 개선/최적화 / Enhancement/optimization / Mejora/optimización
- [ ] 문서 / Documentation / Documentación
- [ ] 테스트 / Test / Prueba

### 해결된 문제 / Issues Addressed / Problemas Abordados
* [VID-221](https://htw-cloud.atlassian.net/browse/VID-221)

### 체크리스트 / Checklist / Lista de Verificación
<!--- Jira 티켓의 허용 기준을 나타내는 데 사용됩니다. /
      Used to represent the acceptance criteria of the Jira ticket / 
      Se utiliza para representar los criterios de aceptación del ticket de Jira -->
- [ ] 설계 표준 충족 / Meets Design Standards / Cumple con los Estándares de Diseño
- [ ] 테스트 통과 / Passes Tests / Pasa las Pruebas
- [ ] 만나다 [완료의 정의](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done) / Meets [Definition of Done](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done) / Satisface [Definición de Hecho](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done)


[VID-221]: https://htw-cloud.atlassian.net/browse/VID-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ