### PR TITLE
DEVO-750-add accessRule for local-rest-devicemanager

### DIFF
--- a/charts/complete-auth-service/values.yaml
+++ b/charts/complete-auth-service/values.yaml
@@ -595,6 +595,24 @@ oathkeeper:
           "mutators": [{
             "handler": "header"
           }]
+        },
+        {
+          "id": "authenticate_rest-devicemanager_get_edge_dev",
+          "match": {
+            "url": "http://<[^/]+>/rest-devicemanager/<v\\d{1,2}(\\.\\d+)?>/edge-devices<(\\?.*)?>",
+            "methods": [
+              "GET"
+            ]
+          },
+          "authenticators": [{
+              "handler": "bearer_token"
+          }],
+          "authorizer": {
+            "handler": "allow"
+          },
+          "mutators": [{
+            "handler": "header"
+          }]
         }
       ]
 


### PR DESCRIPTION
## [ 추가/수정된 구성 요소의 이름 ] / [ Name of Component Added/Modified ] / [ Nombre del Componente Agregado/Modificado ]
<!--- 여기에서 변경 사항을 자세히 설명하세요 / Describe your changes in detail here / Describa sus cambios en detalle aquí  -->
- added oathkeeper accessRule for edge rest-devicemanager
- By default, I understand that ps script uses this values file, if I'm wrong about that, I'd appreciate some feedback.

### 변경 유형 / Types of Changes / Tipos de Cambios
<!--- 귀하의 코드는 어떤 유형의 변경을 도입합니까? / What types of changes does your code introduce? / ¿Qué tipos de cambios introduce su código? -->
- [ ] 핵심 / Core / Centro
- [ ] 버그 수정 / Bugfix / Corrección de Error
- [X] 새 구성 요소 / New component / Nuevo componente
- [ ] 개선/최적화 / Enhancement/optimization / Mejora/optimización
- [ ] 문서 / Documentation / Documentación
- [ ] 테스트 / Test / Prueba

### 해결된 문제 / Issues Addressed / Problemas Abordados
* [DEVO-750](https://htw-cloud.atlassian.net/browse/DEVO-750)

### 체크리스트 / Checklist / Lista de Verificación
<!--- Jira 티켓의 허용 기준을 나타내는 데 사용됩니다. /
      Used to represent the acceptance criteria of the Jira ticket / 
      Se utiliza para representar los criterios de aceptación del ticket de Jira -->
- [ ] 설계 표준 충족 / Meets Design Standards / Cumple con los Estándares de Diseño
- [ ] 테스트 통과 / Passes Tests / Pasa las Pruebas
- [ ] 만나다 [완료의 정의](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done) / Meets [Definition of Done](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done) / Satisface [Definición de Hecho](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done)


[DEVO-750]: https://htw-cloud.atlassian.net/browse/DEVO-750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ