### PR TITLE
Update values.yaml templates for auth and org-management services

### DIFF
--- a/charts/complete-auth-service/Chart.yaml
+++ b/charts/complete-auth-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.26
+version: 0.1.27
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/complete-auth-service/values.yaml
+++ b/charts/complete-auth-service/values.yaml
@@ -17,10 +17,14 @@ image:
       value: YOUR_AWS_REGION
     - name: AWS_ACCOUNT
       value: "YOUR_AWS_ACCOUNT_ID"
-    - name: PRODUCER_QUEUE
-      value: YOUR_SQS_PRODUCER_QUEUE
-    - name: CONSUMER_QUEUE
-      value: YOUR_SQS_CONSUMER_QUEUE
+    - name: AUTH_SERVICE_QUEUE
+      value: YOUR_SQS_AUTH_SERVICE_QUEUE
+    - name: ORG_SERVICE_QUEUE
+      value: YOUR_SQS_ORG_SERVICE_QUEUE
+    - name: DEVICE_SERVICE_QUEUE
+      value: YOUR_SQS_DEVICE_SERVICE_QUEUE
+    - name: SITE_SERVICE_QUEUE
+      value: YOUR_SQS_SITE_SERVICE_QUEUE
   livenessProbe: livez
   readinessProbe: readyz
 sidecarimage:
@@ -34,8 +38,8 @@ service:
   type: ClusterIP
 resources:
   requests:
-    cpu: 100m
-    memory: 250Mi
+    cpu: 250m
+    memory: 750Mi
 # TODO: This should be made toggleable for edge vs cloud...
 serviceAccount:
   name: "auth"
@@ -77,7 +81,7 @@ oathkeeper:
         remote_json:
           enabled: true
           config:
-            remote: http://auth-service-keto-read/relation-tuples/check
+            remote: http://auth-service-complete-auth-service:3000/v2/authorization-checks
             forward_response_headers_to_upstream: []
             payload: |
               {
@@ -97,11 +101,10 @@ oathkeeper:
     accessRules: |
       [
         {
-          "id": "authorize_user_management",
+          "id": "authorize_create_user",
           "match": {
             "url": "http://<[^/]+>/auth<(/v[1-9]{1,2}){0,1}>/<organizations>/<[[:alnum:],-]+>/<users>",
             "methods": [
-              "GET",
               "POST"
             ]
           },
@@ -109,7 +112,35 @@ oathkeeper:
               "handler": "bearer_token"
           }],
           "authorizer": {
-            "handler": "remote_json"
+            "handler": "remote_json",
+            "config": {
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
+              "forward_response_headers_to_upstream": [],
+              "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 4 }}\", \"relation\": \"create-users\", \"subject_id\": \"{{ print .Subject }}\"}"
+            }
+          },
+          "mutators": [{
+            "handler": "header"
+          }]
+        },
+        {
+          "id": "authorize_view_user",
+          "match": {
+            "url": "http://<[^/]+>/auth<(/v[1-9]{1,2}){0,1}>/<organizations>/<[[:alnum:],-]+>/<users>",
+            "methods": [
+              "GET"
+            ]
+          },
+          "authenticators": [{
+              "handler": "bearer_token"
+          }],
+          "authorizer": {
+            "handler": "remote_json",
+            "config": {
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
+              "forward_response_headers_to_upstream": [],
+              "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 4 }}\", \"relation\": \"view-users\", \"subject_id\": \"{{ print .Subject }}\"}"
+            }
           },
           "mutators": [{
             "handler": "header"
@@ -129,7 +160,7 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 4 }}\", \"relation\": \"delete-users\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
@@ -152,7 +183,7 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 4 }}\", \"relation\": \"update-users\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
@@ -173,7 +204,12 @@ oathkeeper:
               "handler": "bearer_token"
           }],
           "authorizer": {
-            "handler": "remote_json"
+            "handler": "remote_json",
+            "config": {
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
+              "forward_response_headers_to_upstream": [],
+              "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 4 }}\", \"relation\": \"create-roles\", \"subject_id\": \"{{ print .Subject }}\"}"
+            }
           },
           "mutators": [{
             "handler": "header"
@@ -193,7 +229,7 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 3 }}\", \"relation\": \"view-roles\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
@@ -214,7 +250,12 @@ oathkeeper:
               "handler": "bearer_token"
           }],
           "authorizer": {
-            "handler": "remote_json"
+            "handler": "remote_json",
+            "config": {
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
+              "forward_response_headers_to_upstream": [],
+              "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 4 }}\", \"relation\": \"create-role-assignments\", \"subject_id\": \"{{ print .Subject }}\"}"
+            }
           },
           "mutators": [{
             "handler": "header"
@@ -232,12 +273,7 @@ oathkeeper:
               "handler": "bearer_token"
           }],
           "authorizer": {
-            "handler": "remote_json",
-            "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
-              "forward_response_headers_to_upstream": [],
-              "payload": "{\"namespace\": \"platform\", \"object\": \"entitlement\", \"relation\": \"get-entitlements\", \"subject_id\": \"{{ print .Subject }}\"}"
-            }
+            "handler": "allow"
           },
           "mutators": [{
             "handler": "header"
@@ -257,7 +293,7 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 3 }}\", \"relation\": \"create-groups\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
@@ -280,9 +316,55 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 3 }}\", \"relation\": \"delete-groups\", \"subject_id\": \"{{ print .Subject }}\"}"
+            }
+          },
+          "mutators": [{
+            "handler": "header"
+          }]
+        },
+        {
+          "id": "authorize_get_groups",
+          "match": {
+            "url": "http://<[^/]+>/auth<(/v[1-9]{1,2}){0,1}>/organizations/<[[:alnum:],-]+>/groups<(/[[:alnum:],-]+){0,1}>",
+            "methods": [
+              "GET"
+            ]
+          },
+          "authenticators": [{
+              "handler": "bearer_token"
+          }],
+          "authorizer": {
+            "handler": "remote_json",
+            "config": {
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
+              "forward_response_headers_to_upstream": [],
+              "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 3 }}\", \"relation\": \"view-groups\", \"subject_id\": \"{{ print .Subject }}\"}"
+            }
+          },
+          "mutators": [{
+            "handler": "header"
+          }]
+        },
+        {
+          "id": "authorize_update_groups",
+          "match": {
+            "url": "http://<[^/]+>/auth<(/v[1-9]{1,2}){0,1}>/organizations/<[[:alnum:],-]+>/groups/<[[:alnum:],-]+>",
+            "methods": [
+              "PATCH"
+            ]
+          },
+          "authenticators": [{
+              "handler": "bearer_token"
+          }],
+          "authorizer": {
+            "handler": "remote_json",
+            "config": {
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
+              "forward_response_headers_to_upstream": [],
+              "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 3 }}\", \"relation\": \"update-groups\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
           },
           "mutators": [{
@@ -303,9 +385,9 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
-              "payload": "{\"namespace\": \"platform\", \"object\": \"organization\", \"relation\": \"create-organization\", \"subject_id\": \"{{ print .Subject }}\"}"
+              "payload": "{\"namespace\": \"platform\", \"object\": \"organization\", \"relation\": \"create-customers-and-organizations\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
           },
           "mutators": [{
@@ -326,7 +408,7 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"platform\", \"object\": \"organization\", \"relation\": \"delete-organizations\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
@@ -338,7 +420,7 @@ oathkeeper:
         {
           "id": "authorize_get_organizations",
           "match": {
-            "url": "http://<[^/]+>/customer<(/v[1-9]{1,2}){0,1}>/organizations",
+            "url": "http://<[^/]+>/customer<(/v[1-9]{1,2}){0,1}>/organizations<(/[[:alnum:],-]+){0,1}>",
             "methods": [
               "GET"
             ]
@@ -349,7 +431,7 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"platform\", \"object\": \"organization\", \"relation\": \"view-organizations\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
@@ -390,7 +472,7 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 4 }}\", \"relation\": \"view-assigned-roles\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
@@ -413,7 +495,7 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 4 }}\", \"relation\": \"delete-roles\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
@@ -436,7 +518,7 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 4 }}\", \"relation\": \"update-users\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
@@ -459,7 +541,7 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"organizations\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 4 }}\", \"relation\": \"update-roles\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
@@ -518,7 +600,7 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"cameras\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 1 }}\", \"relation\": \"camera-view-live-stream-from-device\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
@@ -541,7 +623,7 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"cameras\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 1 }}\", \"relation\": \"camera-view-recorded-video\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
@@ -564,7 +646,7 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"cameras\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 1 }}\", \"relation\": \"camera-view-video-recording-settings\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
@@ -587,7 +669,7 @@ oathkeeper:
           "authorizer": {
             "handler": "remote_json",
             "config": {
-              "remote": "http://auth-service-keto-read/relation-tuples/check",
+              "remote": "http://auth-service-complete-auth-service:3000/v2/authorization-checks",
               "forward_response_headers_to_upstream": [],
               "payload": "{\"namespace\": \"cameras\", \"object\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 1 }}\", \"relation\": \"camera-view-recorded-video\", \"subject_id\": \"{{ print .Subject }}\"}"
             }
@@ -595,6 +677,166 @@ oathkeeper:
           "mutators": [{
             "handler": "header"
           }]
+        },
+        {
+          "id": "authenticate_rest-devicemanager_configurations_datetime",
+          "match": {
+            "url": "http://<[^/]+>/rest-devicemanager/<v\\d{1,2}(\\.\\d+)?>/edge-devices/<([0-9A-Fa-f]{2}){6}>/configurations/date-time<(\\?.*)?>",
+            "methods": ["GET", "PUT"]
+          },
+          "authenticators": [
+            {
+              "handler": "bearer_token"
+            }
+          ],
+          "authorizer": {
+            "handler": "allow"
+          },
+          "mutators": [
+            {
+              "handler": "header"
+            }
+          ]
+        },
+        {
+          "id": "authenticate_rest-devicemanager_get_edge_devices",
+          "match": {
+            "url": "http://<[^/]+>/rest-devicemanager/<v\\d{1,2}(\\.\\d+)?>/edge-devices<(\\?.*)?>",
+            "methods": ["GET"]
+          },
+          "authenticators": [
+            {
+              "handler": "bearer_token"
+            }
+          ],
+          "authorizer": {
+            "handler": "allow"
+          },
+          "mutators": [
+            {
+              "handler": "header"
+            }
+          ]
+        },
+        {
+          "id": "authenticate_rest-devicemanager_edge_device_management",
+          "match": {
+            "url": "http://<[^/]+>/rest-devicemanager/<v\\d{1,2}(\\.\\d+)?>/edge-devices/<([0-9A-Fa-f]{2}){6}>",
+            "methods": ["POST", "DELETE"]
+          },
+          "authenticators": [
+            {
+              "handler": "bearer_token"
+            }
+          ],
+          "authorizer": {
+            "handler": "allow"
+          },
+          "mutators": [
+            {
+              "handler": "header"
+            }
+          ]
+        },
+        {
+          "id": "authenticate_rest-devicemanager_iot_device_management",
+          "match": {
+            "url": "http://<[^/]+>/rest-devicemanager/<v\\d{1,2}(\\.\\d+)?>/edge-devices/<([0-9A-Fa-f]{2}){6}>/iot-devices/<([0-9A-Fa-f]{2}){6}>",
+            "methods": ["POST"]
+          },
+          "authenticators": [
+            {
+              "handler": "bearer_token"
+            }
+          ],
+          "authorizer": {
+            "handler": "allow"
+          },
+          "mutators": [
+            {
+              "handler": "header"
+            }
+          ]
+        },
+        {
+          "id": "authenticate_rest-devicemanager_iot_device_action",
+          "match": {
+            "url": "http://<[^/]+>/rest-devicemanager/<v\\d{1,2}(\\.\\d+)?>/edge-devices/<([0-9A-Fa-f]{2}){6}>/actions/<[^/]+>",
+            "methods": ["POST"]
+          },
+          "authenticators": [
+            {
+              "handler": "bearer_token"
+            }
+          ],
+          "authorizer": {
+            "handler": "allow"
+          },
+          "mutators": [
+            {
+              "handler": "header"
+            }
+          ]
+        },
+        {
+          "id": "authenticate_rest-devicemanager_move_edge_device",
+          "match": {
+            "url": "http://<[^/]+>/rest-devicemanager/<v\\d{1,2}(\\.\\d+)?>/edge-devices/<([0-9A-Fa-f]{2}){6}>/site",
+            "methods": ["PUT"]
+          },
+          "authenticators": [
+            {
+              "handler": "bearer_token"
+            }
+          ],
+          "authorizer": {
+            "handler": "allow"
+          },
+          "mutators": [
+            {
+              "handler": "header"
+            }
+          ]
+        },
+        {
+          "id": "authenticate_rest-devicemanager_move_iot_device",
+          "match": {
+            "url": "http://<[^/]+>/rest-devicemanager/<v\\d{1,2}(\\.\\d+)?>/iot-devices/<([0-9A-Fa-f]{2}){6}>/site",
+            "methods": ["PUT"]
+          },
+          "authenticators": [
+            {
+              "handler": "bearer_token"
+            }
+          ],
+          "authorizer": {
+            "handler": "allow"
+          },
+          "mutators": [
+            {
+              "handler": "header"
+            }
+          ]
+        },
+        {
+          "id": "authenticate_rest-devicemanager_delete_iot_device",
+          "match": {
+            "url": "http://<[^/]+>/rest-devicemanager/<v\\d{1,2}(\\.\\d+)?>/iot-devices/<([0-9A-Fa-f]{2}){6}>",
+            "methods": ["DELETE"]
+          },
+          "authenticators": [
+            {
+              "handler": "bearer_token"
+            }
+          ],
+          "authorizer": {
+            "handler": "allow"
+          },
+          "mutators": [
+            {
+              "handler": "header"
+            }
+          ]
         }
       ]
 
@@ -603,7 +845,7 @@ kratos:
     enabled: false
   kratos:
     automigration:
-      enabled: false
+      enabled: true
       customCommand:
         - kratos
       customArgs:
@@ -714,7 +956,7 @@ kratos:
 keto:
   keto:
     automigration:
-      enabled: false
+      enabled: true
       customCommand:
         - keto
     config:
@@ -729,6 +971,12 @@ keto:
           name: cameras
         - id: 4
           name: sites
+        - id: 5
+          name: gateways
+        - id: 6
+          name: access-control
+        - id: 7
+          name: groups
       dsn: "postgres://postgres:YOUR_POSTGRES_PASSWORD@YOUR_POSTGRES_HOST:5432/ory?sslmode=disable&max_conn_lifetime=10s"
     log:
       leak_sensitive_values: false

--- a/charts/complete-auth-service/values.yaml
+++ b/charts/complete-auth-service/values.yaml
@@ -17,7 +17,7 @@ image:
       value: YOUR_AWS_REGION
     - name: AWS_ACCOUNT
       value: "YOUR_AWS_ACCOUNT_ID"
-    # Queue name Environment Variables ONLY required for Cloud
+    # Queue name Environment Variables ONLY required for Cloud - TEMPORARY FOR M2
     # - name: AUTH_SERVICE_QUEUE
     #   value: YOUR_SQS_AUTH_SERVICE_QUEUE
     # - name: ORG_SERVICE_QUEUE

--- a/charts/complete-auth-service/values.yaml
+++ b/charts/complete-auth-service/values.yaml
@@ -17,14 +17,15 @@ image:
       value: YOUR_AWS_REGION
     - name: AWS_ACCOUNT
       value: "YOUR_AWS_ACCOUNT_ID"
-    - name: AUTH_SERVICE_QUEUE
-      value: YOUR_SQS_AUTH_SERVICE_QUEUE
-    - name: ORG_SERVICE_QUEUE
-      value: YOUR_SQS_ORG_SERVICE_QUEUE
-    - name: DEVICE_SERVICE_QUEUE
-      value: YOUR_SQS_DEVICE_SERVICE_QUEUE
-    - name: SITE_SERVICE_QUEUE
-      value: YOUR_SQS_SITE_SERVICE_QUEUE
+    # Queue name Environment Variables ONLY required for Cloud
+    # - name: AUTH_SERVICE_QUEUE
+    #   value: YOUR_SQS_AUTH_SERVICE_QUEUE
+    # - name: ORG_SERVICE_QUEUE
+    #   value: YOUR_SQS_ORG_SERVICE_QUEUE
+    # - name: DEVICE_SERVICE_QUEUE
+    #   value: YOUR_SQS_DEVICE_SERVICE_QUEUE
+    # - name: SITE_SERVICE_QUEUE
+    #   value: YOUR_SQS_SITE_SERVICE_QUEUE
   livenessProbe: livez
   readinessProbe: readyz
 sidecarimage:

--- a/charts/complete-org-service/Chart.yaml
+++ b/charts/complete-org-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/complete-org-service/values.yaml
+++ b/charts/complete-org-service/values.yaml
@@ -9,6 +9,8 @@ image:
   hostname: "org"
   domainPath: "customer"
   env:
+    - name: OPERATION_ENV
+      value: edge
     - name: AWS_REGION
       value: YOUR_AWS_REGION
     - name: AWS_ACCOUNT

--- a/charts/complete-org-service/values.yaml
+++ b/charts/complete-org-service/values.yaml
@@ -1,29 +1,29 @@
-postgresUpdater: 
+postgresUpdater:
   image: ghcr.io/htaic/org-management-service-postgres-runner
 image:
   replicaCount: 1
   repository: ghcr.io/htaic/org-management-services
   pullPolicy: Always
   containerPort: 3001
-  tag: 'latest' 
-  hostname: 'org'
-  domainPath: 'customer'
+  tag: "latest"
+  hostname: "org"
+  domainPath: "customer"
   env:
     - name: AWS_REGION
       value: YOUR_AWS_REGION
     - name: AWS_ACCOUNT
       value: "YOUR_AWS_ACCOUNT_ID"
-    - name: PRODUCER_QUEUE
-      value: YOUR_SQS_CONSUMER_QUEUE
-    - name: CONSUMER_QUEUE
-      value: YOUR_SQS_PRODUCER_QUEUE
+    - name: ORG_SERVICE_QUEUE
+      value: YOUR_SQS_ORG_SERVICE_QUEUE
+    - name: AUTH_SERVICE_QUEUE
+      value: YOUR_SQS_AUTH_SERVICE_QUEUE
   livenessProbe: livez
   readinessProbe: readyz
 sidecarimage:
-  name: 'logging-sidecar'
+  name: "logging-sidecar"
   repository: ghcr.io/htaic/platform-logging-service
   pullPolicy: Always
-  tag: 'latest'
+  tag: "latest"
 imagePullSecrets:
   - name: dockerconfigjson-github-com
 service:
@@ -33,7 +33,7 @@ resources:
     cpu: 100m
     memory: 250Mi
 serviceAccount:
-  name: 'org-service'
+  name: "org-service"
   create: true
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::YOUR_AWS_ACCOUNT_ID:role/YOUR_SQS_ROLE

--- a/charts/complete-org-service/values.yaml
+++ b/charts/complete-org-service/values.yaml
@@ -30,8 +30,8 @@ service:
   type: ClusterIP
 resources:
   requests:
-    cpu: 100m
-    memory: 250Mi
+    cpu: 250m
+    memory: 750Mi
 serviceAccount:
   name: "org-service"
   create: true

--- a/charts/complete-org-service/values.yaml
+++ b/charts/complete-org-service/values.yaml
@@ -15,7 +15,7 @@ image:
       value: YOUR_AWS_REGION
     - name: AWS_ACCOUNT
       value: "YOUR_AWS_ACCOUNT_ID"
-    # Queue name Environment Variables ONLY required for Cloud
+    # Queue name Environment Variables ONLY required for Cloud - TEMPORARY FOR M2
     # - name: ORG_SERVICE_QUEUE
     #   value: YOUR_SQS_ORG_SERVICE_QUEUE
     # - name: AUTH_SERVICE_QUEUE

--- a/charts/complete-org-service/values.yaml
+++ b/charts/complete-org-service/values.yaml
@@ -15,10 +15,11 @@ image:
       value: YOUR_AWS_REGION
     - name: AWS_ACCOUNT
       value: "YOUR_AWS_ACCOUNT_ID"
-    - name: ORG_SERVICE_QUEUE
-      value: YOUR_SQS_ORG_SERVICE_QUEUE
-    - name: AUTH_SERVICE_QUEUE
-      value: YOUR_SQS_AUTH_SERVICE_QUEUE
+    # Queue name Environment Variables ONLY required for Cloud
+    # - name: ORG_SERVICE_QUEUE
+    #   value: YOUR_SQS_ORG_SERVICE_QUEUE
+    # - name: AUTH_SERVICE_QUEUE
+    #   value: YOUR_SQS_AUTH_SERVICE_QUEUE
   livenessProbe: livez
   readinessProbe: readyz
 sidecarimage:


### PR DESCRIPTION
## Description
Updates the values.yaml files for the auth and org-management services to bring them up to date, this includes;
- Updating the environment variables for the additional queues for device and site management
- Adding new keto namespaces for gateways, access-controls and groups
- Updating the oathkeeper rules section to include new rules and the remote_json authorizers new endpoint

### 변경 유형 / Types of Changes / Tipos de Cambios
<!--- 귀하의 코드는 어떤 유형의 변경을 도입합니까? / What types of changes does your code introduce? / ¿Qué tipos de cambios introduce su código? -->
- [x] 핵심 / Core / Centro
- [ ] 버그 수정 / Bugfix / Corrección de Error
- [ ] 새 구성 요소 / New component / Nuevo componente
- [ ] 개선/최적화 / Enhancement/optimization / Mejora/optimización
- [ ] 문서 / Documentation / Documentación
- [ ] 테스트 / Test / Prueba

### 해결된 문제 / Issues Addressed / Problemas Abordados
* [KEY-123](https://htw-cloud.atlassian.net/browse/KEY-123)

### 체크리스트 / Checklist / Lista de Verificación
<!--- Jira 티켓의 허용 기준을 나타내는 데 사용됩니다. /
      Used to represent the acceptance criteria of the Jira ticket / 
      Se utiliza para representar los criterios de aceptación del ticket de Jira -->
- [ ] 설계 표준 충족 / Meets Design Standards / Cumple con los Estándares de Diseño
- [ ] 테스트 통과 / Passes Tests / Pasa las Pruebas
- [ ] 만나다 [완료의 정의](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done) / Meets [Definition of Done](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done) / Satisface [Definición de Hecho](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done)
