### PR TITLE
chore: AN-978 enable readiness and liveness for portal-container

### DIFF
--- a/charts/anaheim-portal/charts/anaheim-container/Chart.yaml
+++ b/charts/anaheim-portal/charts/anaheim-container/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/anaheim-portal/charts/anaheim-container/values.yaml
+++ b/charts/anaheim-portal/charts/anaheim-container/values.yaml
@@ -4,6 +4,8 @@ image:
   pullPolicy: Always
   containerPort: 3000
   tag: "latest"
+  livenessProbe: livez
+  readinessProbe: readyz
   hostname: anaheim-container
   envFrom:
     secretRefs:

--- a/charts/anaheim-portal/charts/anaheim-training-portlet/Chart.yaml
+++ b/charts/anaheim-portal/charts/anaheim-training-portlet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/anaheim-portal/charts/anaheim-training-portlet/templates/deployment.yaml
+++ b/charts/anaheim-portal/charts/anaheim-training-portlet/templates/deployment.yaml
@@ -62,6 +62,20 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /{{ .Values.image.livenessProbe }}
+              port: http
+            {{- if .Values.image.livenessProbePeriodSeconds }}
+            periodSeconds: {{ .Values.image.livenessProbePeriodSeconds }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /{{ .Values.image.readinessProbe }}
+              port: http
+            {{- if .Values.image.readinessProbePeriodSeconds }}
+            periodSeconds: {{ .Values.image.readinessProbePeriodSeconds }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/anaheim-portal/charts/anaheim-training-portlet/values.yaml
+++ b/charts/anaheim-portal/charts/anaheim-training-portlet/values.yaml
@@ -4,6 +4,8 @@ image:
   pullPolicy: Always
   containerPort: 3001
   tag: "latest"
+  livenessProbe: livez
+  readinessProbe: readyz
   hostname: anaheim-training-portlet
   domainPath: "training"
   envFrom:

--- a/charts/anaheim-portal/charts/anaheim-verification-portlet/Chart.yaml
+++ b/charts/anaheim-portal/charts/anaheim-verification-portlet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/anaheim-portal/charts/anaheim-verification-portlet/templates/deployment.yaml
+++ b/charts/anaheim-portal/charts/anaheim-verification-portlet/templates/deployment.yaml
@@ -62,6 +62,20 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /{{ .Values.image.livenessProbe }}
+              port: http
+            {{- if .Values.image.livenessProbePeriodSeconds }}
+            periodSeconds: {{ .Values.image.livenessProbePeriodSeconds }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /{{ .Values.image.readinessProbe }}
+              port: http
+            {{- if .Values.image.readinessProbePeriodSeconds }}
+            periodSeconds: {{ .Values.image.readinessProbePeriodSeconds }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/anaheim-portal/charts/anaheim-verification-portlet/values.yaml
+++ b/charts/anaheim-portal/charts/anaheim-verification-portlet/values.yaml
@@ -4,6 +4,8 @@ image:
   pullPolicy: Always
   containerPort: 3002
   tag: "latest"
+  livenessProbe: livez
+  readinessProbe: readyz
   hostname: anaheim-verification-portlet
   domainPath: "verify"
   envFrom:


### PR DESCRIPTION
## Enabled readiness and liveness checks for portal-container and portlets in values.yaml and versioned charts file

**Portal PR: https://github.com/htaic/anaheim-portal/pull/382**

### 변경 유형 / Types of Changes / Tipos de Cambios
<!--- 귀하의 코드는 어떤 유형의 변경을 도입합니까? / What types of changes does your code introduce? / ¿Qué tipos de cambios introduce su código? -->
- [ ] 핵심 / Core / Centro
- [ ] 버그 수정 / Bugfix / Corrección de Error
- [ ] 새 구성 요소 / New component / Nuevo componente
- [x] 개선/최적화 / Enhancement/optimization / Mejora/optimización
- [ ] 문서 / Documentation / Documentación
- [ ] 테스트 / Test / Prueba

### 해결된 문제 / Issues Addressed / Problemas Abordados
* [AN-978](https://htw-cloud.atlassian.net/browse/AN-978)
* [AN-979](https://htw-cloud.atlassian.net/browse/AN-979)
* [AN-980](https://htw-cloud.atlassian.net/browse/AN-980)

### 체크리스트 / Checklist / Lista de Verificación
<!--- Jira 티켓의 허용 기준을 나타내는 데 사용됩니다. /
      Used to represent the acceptance criteria of the Jira ticket / 
      Se utiliza para representar los criterios de aceptación del ticket de Jira -->
- [ ] 설계 표준 충족 / Meets Design Standards / Cumple con los Estándares de Diseño
- [ ] 테스트 통과 / Passes Tests / Pasa las Pruebas
- [ ] 만나다 [완료의 정의](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done) / Meets [Definition of Done](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done) / Satisface [Definición de Hecho](https://htw-cloud.atlassian.net/wiki/spaces/DEV/pages/3604642/Definition+of+Done)
